### PR TITLE
fix: ensure color array shape when no centers

### DIFF
--- a/DotImporterMain.py
+++ b/DotImporterMain.py
@@ -167,6 +167,8 @@ def save_centers_csv(csv_path: Path, centers, areas):
 # ---------- Utility: colors at centers & CSV ----------
 def sample_colors(rgb: np.ndarray, centers):
     H, W, _ = rgb.shape
+    if len(centers) == 0:
+        return np.empty((0, 3), dtype=np.uint8)
     cols = []
     for x, y in centers:
         xi = int(round(float(x)))


### PR DESCRIPTION
## Summary
- avoid numpy vstack dimension mismatch by ensuring sampled colors are 2D even when no centers

## Testing
- `python -m py_compile DotImporterMain.py`


------
https://chatgpt.com/codex/tasks/task_e_68a42570b620832f8d72cd6b2893b19e