### PR TITLE
Gracefully handle missing scikit-image dependency

### DIFF
--- a/Convert/utils.py
+++ b/Convert/utils.py
@@ -1,7 +1,28 @@
 import numpy as np
 from PIL import Image, ImageFilter
-from skimage.morphology import skeletonize
 from scipy.spatial import cKDTree
+
+try:
+    from skimage.morphology import skeletonize  # type: ignore
+    _SKIMAGE_AVAILABLE = True
+except ImportError:  # pragma: no cover - handled gracefully
+    skeletonize = None
+    _SKIMAGE_AVAILABLE = False
+
+
+def check_skimage() -> tuple[bool, str]:
+    """Return availability of :mod:`scikit-image`.
+
+    Returns
+    -------
+    (bool, str)
+        ``True`` and empty message if scikit-image is available. ``False`` and a
+        guidance string otherwise.
+    """
+
+    if _SKIMAGE_AVAILABLE:
+        return True, ""
+    return False, "scikit-image が見つかりません。`pip install scikit-image` を実行してください。"
 
 
 def load_skeleton(image_path, blur_radius=0.5, thresh_scale=0.8):

--- a/DotImporterMain.py
+++ b/DotImporterMain.py
@@ -17,6 +17,8 @@ from pathlib import Path
 import csv
 import numpy as np
 
+from Convert.utils import check_skimage
+
 
 # ---------- Utility: image -> grayscale & RGB (numpy) ----------
 def load_image_grayscale_np(img_path: str):
@@ -319,6 +321,11 @@ class DPI_OT_detect_and_create(Operator):
         p = context.scene.dpi_props
         if not p.image_path:
             self.report({'ERROR'}, "Image not set")
+            return {'CANCELLED'}
+
+        ok, msg = check_skimage()
+        if not ok:
+            self.report({'ERROR'}, msg or "scikit-image が見つかりません")
             return {'CANCELLED'}
 
         try:


### PR DESCRIPTION
## Summary
- avoid hard failure when `scikit-image` is absent
- report a helpful error message before running dot detection

## Testing
- `python -m py_compile Convert/utils.py DotImporterMain.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1644d2710832f8e146594c86eb974