### PR TITLE
Avoid overlap when padding vertices

### DIFF
--- a/DotImporterMain.py
+++ b/DotImporterMain.py
@@ -225,7 +225,7 @@ def create_vertices_object(name, centers_px, img_w, img_h, unit_per_px, origin_m
             step = max(spacing, 1.0)
             xs = []
             ys = []
-            x, y = 0.0, 0.0
+            x, y = 0.0, float(img_h)
             for _ in range(extra):
                 xs.append(x)
                 ys.append(y)
@@ -345,7 +345,7 @@ class DPIProps(PropertyGroup):
     )
     max_points: IntProperty(
         name="Max Points",
-        description="Maximum number of vertices to create (0 for unlimited). Missing points are placed from the top-left with uniform spacing.",
+        description="Maximum number of vertices to create (0 for unlimited). Missing points are placed outside the image bounds with uniform spacing.",
         default=0, min=0
     )
     save_csv: BoolProperty(


### PR DESCRIPTION
## Summary
- Place any extra vertices beyond detected points outside the image bounds to avoid overlapping with existing ones
- Update max points property description to note new placement behavior

## Testing
- `python -m py_compile DotImporterMain.py`
- `python -m py_compile Convert/Line2Dots.py Convert/Shape2Dots.py Convert/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1b03efb8c832fa0408e0abc53f1a7