### PR TITLE
Add outline toggle for shape conversion

### DIFF
--- a/Convert/Shape2Dots.py
+++ b/Convert/Shape2Dots.py
@@ -144,6 +144,7 @@ def shape_image_to_dots(
     max_points: int = 0,
     resize_to: int = 0,
     detect_color_boundary: bool = False,
+    outline: bool = True,
 ) -> np.ndarray:
     """Sample points from a silhouette image.
 
@@ -166,6 +167,9 @@ def shape_image_to_dots(
         aspect ratio) before processing. ``0`` disables resizing.
     detect_color_boundary:
         If ``True``, also detect and sample boundaries between color regions.
+    outline:
+        If ``True``, extract and sample the silhouette outline. ``False``
+        skips outline extraction and only applies ``fill_shape``.
 
     Returns
     -------
@@ -188,6 +192,15 @@ def shape_image_to_dots(
 
     if fill_mode == 'TOPOLOGY':
         pts = fill_shape(mask, eff_spacing, fill_mode)
+        pts *= scale
+        return pts
+
+    if not outline:
+        pts = fill_shape(mask, eff_spacing, fill_mode)
+        if max_points > 0 and len(pts) > max_points:
+            while len(pts) > max_points and eff_spacing > 0:
+                eff_spacing *= len(pts) / max_points
+                pts = fill_shape(mask, eff_spacing, fill_mode)
         pts *= scale
         return pts
 

--- a/DotImporterMain.py
+++ b/DotImporterMain.py
@@ -310,6 +310,11 @@ class DPIProps(PropertyGroup):
         description="Include boundaries between color regions for shape conversion",
         default=False,
     )
+    outline: BoolProperty(
+        name="Outline",
+        description="Generate outline from the silhouette for shape conversion",
+        default=True,
+    )
     resize_to: IntProperty(
         name="Resize Max",
         description=(
@@ -414,6 +419,7 @@ class DPI_OT_detect_and_create(Operator):
                 max_points=p.max_points,
                 resize_to=p.resize_to,
                 detect_color_boundary=p.detect_color_boundary,
+                outline=p.outline,
             )
         else:
             centers, _ = detect_centers(gray, p.threshold, p.invert, p.min_area_px)
@@ -479,6 +485,8 @@ class DPI_PT_panel(Panel):
         box = layout.box()
         box.label(text="Detection")
         box.prop(p, "conversion_mode")
+        if p.conversion_mode == 'SHAPE':
+            box.prop(p, "outline", text="Outline を生成する")
         box.prop(p, "threshold")
         box.prop(p, "invert")
         box.prop(p, "min_area_px")


### PR DESCRIPTION
## Summary
- add optional `outline` flag to shape-based conversion to skip silhouette extraction
- expose "Outline を生成する" checkbox for shape mode UI
- pass outline flag from operator to conversion routine

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3023e2400832f9cd0608e3c3bce09