### PR TITLE
Avoid ambiguous array truth value in outline limit computation

### DIFF
--- a/Convert/Shape2Dots.py
+++ b/Convert/Shape2Dots.py
@@ -219,7 +219,7 @@ def shape_image_to_dots(
     outline_limit = max_points
     fill_limit = 0
     if max_points > 0 and fill_mode != 'NONE':
-        outline_limit = max_points // 2 if outline else 0
+        outline_limit = max_points // 2 if outline.any() else 0
         fill_limit = max_points - outline_limit
 
     eff_spacing_outline = eff_spacing


### PR DESCRIPTION
## Summary
- fix ValueError from ambiguous truth value when max_points with fill mode
- ensure outline_max_points uses `outline.any()`

## Testing
- `python -m py_compile Convert/Shape2Dots.py DotImporterMain.py`
- `python - <<'PY'
from Convert.Shape2Dots import shape_image_to_dots
from PIL import Image
import numpy as np, os

img = Image.new('L', (20,20), color=255)
for y in range(5,15):
    for x in range(5,15):
        img.putpixel((x,y), 0)
img.save('dummy.png')

dots = shape_image_to_dots('dummy.png', spacing=2, fill_mode='GRID', max_points=10, outline=True)
print("Generated", len(dots), "points")
os.remove('dummy.png')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b32c9b1550832fa8380f29658890fc