### PR TITLE
Fix mesh sampling spacing and max point limits

### DIFF
--- a/Convert/Shape2Dots.py
+++ b/Convert/Shape2Dots.py
@@ -86,7 +86,7 @@ def fill_shape(mask: np.ndarray, spacing: float, mode: str) -> np.ndarray:
             if yi >= H:
                 continue
             offset = (spacing / 2.0) if (row % 2) == 1 else 0.0
-            xs = np.arange(offset, W, spacing)
+            xs = np.arange(offset, max(W - 1, 0) + 1e-6, spacing)
             for x in xs:
                 xi = int(round(x))
                 if xi < W and mask[yi, xi]:
@@ -115,9 +115,11 @@ def fill_shape(mask: np.ndarray, spacing: float, mode: str) -> np.ndarray:
         tree = None
         area = int(mask.sum())
         max_trials = area * 5 if area > 0 else 0
+        max_x = max(W - 1, 0)
+        max_y = max(H - 1, 0)
         for _ in range(max_trials):
-            x = np.random.uniform(0, W)
-            y = np.random.uniform(0, H)
+            x = np.random.uniform(0, max_x) if max_x > 0 else 0.0
+            y = np.random.uniform(0, max_y) if max_y > 0 else 0.0
             xi, yi = int(x), int(y)
             if xi >= W or yi >= H or not mask[yi, xi]:
                 continue

--- a/DotImporterMain.py
+++ b/DotImporterMain.py
@@ -645,8 +645,8 @@ class DPI_OT_mesh_to_dots(Operator):
             min_uv = coords2d.min(axis=0)
             coords_shift = coords2d - min_uv
             max_uv = coords_shift.max(axis=0)
-            W = max(1, int(np.ceil(max_uv[0] / spacing)) + 1)
-            H = max(1, int(np.ceil(max_uv[1] / spacing)) + 1)
+            W = max(1, int(np.floor(max_uv[0] / spacing)) + 1)
+            H = max(1, int(np.floor(max_uv[1] / spacing)) + 1)
             img = Image.new('1', (W, H), 0)
             draw = ImageDraw.Draw(img)
             poly_px = [((u) / spacing, (v) / spacing) for u, v in coords_shift]
@@ -665,6 +665,8 @@ class DPI_OT_mesh_to_dots(Operator):
             return {'CANCELLED'}
 
         pts = np.unique(np.round(np.array(points, dtype=float), 6), axis=0)
+        if p.max_points > 0 and len(pts) > p.max_points:
+            pts = pts[:p.max_points]
         create_points_object(p.object_name or "MeshDots", pts, p.collection_name)
         self.report({'INFO'}, f"Created {len(pts)} vertices from mesh")
         return {'FINISHED'}
@@ -718,8 +720,8 @@ class DPI_OT_path_to_dots(Operator):
                 min_uv = coords2d.min(axis=0)
                 coords_shift = coords2d - min_uv
                 max_uv = coords_shift.max(axis=0)
-                W = max(1, int(np.ceil(max_uv[0] / spacing)) + 1)
-                H = max(1, int(np.ceil(max_uv[1] / spacing)) + 1)
+                W = max(1, int(np.floor(max_uv[0] / spacing)) + 1)
+                H = max(1, int(np.floor(max_uv[1] / spacing)) + 1)
                 img = Image.new('1', (W, H), 0)
                 draw = ImageDraw.Draw(img)
                 poly_px = [((u) / spacing, (v) / spacing) for u, v in coords_shift]


### PR DESCRIPTION
## Summary
- prevent MeshToDots and PathToDots from sampling beyond mesh bounds
- enforce Max Points limit when generating dots from meshes
- keep SemiGrid and Random fill modes within mask bounds

## Testing
- `python -m py_compile DotImporterMain.py Convert/Shape2Dots.py`

------
https://chatgpt.com/codex/tasks/task_e_68b332d4699c832fba978123d256ef21